### PR TITLE
Bugfix/fix sitedescription p wrap

### DIFF
--- a/src/lib/components/SiteDescription.svelte
+++ b/src/lib/components/SiteDescription.svelte
@@ -16,6 +16,6 @@
 
 <style lang="scss">
 	p {
-		white-space: nowrap;
+		max-width: 100%;
 	}
 </style>

--- a/src/lib/components/SiteDescription.svelte
+++ b/src/lib/components/SiteDescription.svelte
@@ -13,3 +13,9 @@
 		target="_blank">url</a
 	>.
 </p>
+
+<style lang="scss">
+	p {
+		white-space: nowrap;
+	}
+</style>


### PR DESCRIPTION
# Description

Currently, when hovering over the anchor element on the `SiteDescription` component, it wraps onto the next line. This looks unpleasing and is unnecessary. By changing the max-width for this specific component, we can ensure that the text doesn't unnecessarily wrap when hovering over the anchor element.

### Before
![before](https://github.com/HBO-i/ictresearchmethods.nl/assets/99080092/d220ffab-5632-47a6-a4b6-15f247564321)

### Before hover
![before_hover](https://github.com/HBO-i/ictresearchmethods.nl/assets/99080092/07543d2a-704c-4390-958a-f3bf89ac952a)

### After hover
![after_hover](https://github.com/HBO-i/ictresearchmethods.nl/assets/99080092/8bc59d51-ba2e-4411-b89c-49225cc1e936)

### After hover on smaller size
![after_hover_small](https://github.com/HBO-i/ictresearchmethods.nl/assets/99080092/1d0ace42-3fa9-448e-81cf-22f4e0671dc5)

## Type of change

Please select the option that is relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] All the required documentation is added.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
