### PR TITLE
Hotfix/176/fix method content missmatch

### DIFF
--- a/src/content/methods/text/extra/joker.md
+++ b/src/content/methods/text/extra/joker.md
@@ -1,13 +1,12 @@
 ---
 name: "Joker"
-why: "With many eyeballs on the code, all bugs are shallow. Colleagues can help you find bugs and improve the quality of your source code."
-how: "Code reviews can be done in many ways. The code can be presented on a big screen, so the entire team can do the review together. You can also ask one or two peers to simply sit behind your desk while you talk them through your code. Code analysis can also be a part of the workflow (e.g. every commit must be reviewed by someone else)."
+why: "This set of cards gives you an overview of methods you can use, but there are many others that might fit your goals better."
+how: "Read books, talk to people, use card sets like this one and see if you can find the best method for achieving your research goal."
 practice: "Code review sessions are often incorporated into software development projects. In Scrum, code reviews can be part of the ‘definition of done’. Pair programming can also be an effective way to let your work be continuously reviewed by a peer."
 ingredients: [
-"Peers with a critical view.",
-"A willingness to improve weak points in your code.",
-"Code standards, a code style guide, checklists, etc.",
-"Use a tool or template like Business Model Canvas."
+"A clear idea of what research goal you are pursuing, or which (type of) question you want to answer.",
+"Sources of research methods, like books or people.",
+"The willingness to aim for ‘yes, this is it’ instead of ‘yes, this will do’."
 ]
 category: "extra"
 phases: [

--- a/src/content/methods/text/extra/joker.md
+++ b/src/content/methods/text/extra/joker.md
@@ -2,7 +2,7 @@
 name: "Joker"
 why: "This set of cards gives you an overview of methods you can use, but there are many others that might fit your goals better."
 how: "Read books, talk to people, use card sets like this one and see if you can find the best method for achieving your research goal."
-practice: "Code review sessions are often incorporated into software development projects. In Scrum, code reviews can be part of the ‘definition of done’. Pair programming can also be an effective way to let your work be continuously reviewed by a peer."
+practice: "That is up to you. Good luck!"
 ingredients: [
 "A clear idea of what research goal you are pursuing, or which (type of) question you want to answer.",
 "Sources of research methods, like books or people.",

--- a/src/content/methods/text/field/document-analysis.md
+++ b/src/content/methods/text/field/document-analysis.md
@@ -1,13 +1,13 @@
 ---
 name: "Document analysis"
-why: "Find out if what you are planning to do has already been done (in full or in part) by someone else."
-how: "Identify existing solutions that may solve the problem (or a part thereof) you are trying to fix with your solution. Decide if it is worth the effort to recreate their work, or whether it is better to simply buy it from them or embed their work in yours."
-practice: "Most companies build their work on what others have already done. This happens a lot in the open source community, but also in commercial products."
+why: "Documentation produced by the company can be a great first resource for understanding the organisation you are working for and their work processes."
+how: "Ask for the company’s most important internal documents. Typical sources are company or product websites, internal documentation, annual plans and product information. Study those documents to understand the company’s culture and way of working."
+practice: "Document analysis is typically performed in the early stages of a project."
 ingredients: [
-"A list of available products that have some overlap with the one you intend to build.",
-"Someone with experience in using or developing similar products (could be yourself).",
-"Eagerness to find partial solutions developed by others.",
-"An open view: a near-fit might be sufficient to consider."
+"Access to company materials.",
+"Time to read and comprehend the materials.",
+"A keen eye for the difference between the paper and the actual reality.",
+"A clear set of questions about the organisation."
 ]
 category: "field"
 phases: [

--- a/src/content/methods/text/lab/a-b-testing.md
+++ b/src/content/methods/text/lab/a-b-testing.md
@@ -1,13 +1,12 @@
 ---
 name: "A/B testing"
-why: "Find out if what you are planning to do has already been done (in full or in part) by someone else."
-how: "Identify existing solutions that may solve the problem (or a part thereof) you are trying to fix with your solution. Decide if it is worth the effort to recreate their work, or whether it is better to simply buy it from them or embed their work in yours."
-practice: "Most companies build their work on what others have already done. This happens a lot in the open source community, but also in commercial products."
+why: "A minor change in a design may alter user behaviour in ways that are hard to detect in a usability test. An A/B test allows you to compare real-world user behaviour across different versions of a product. "
+how: "In an A/B test, the user is presented with one of two versions of an interactive product. Remote software records metrics for user behaviour. These metrics are compared between the two versions to see which alternative is better. Sometimes, more than two alternatives are tested: A/B/X testing. "
+practice: "Google does a lot of A/B testing on its search services. The tiniest details can matter to Google because they have so many users. Some companies also use the A/B experimental design for testing concepts, rather than finished products. "
 ingredients: [
-"A list of available products that have some overlap with the one you intend to build.",
-"Someone with experience in using or developing similar products (could be yourself).",
-"Eagerness to find partial solutions developed by others.",
-"An open view: a near-fit might be sufficient to consider."
+"Specialised software.",
+"Reliable metrics.",
+"A large number of users."
 ]
 category: "lab"
 phases: [

--- a/src/content/methods/text/workshop/brainstorm.md
+++ b/src/content/methods/text/workshop/brainstorm.md
@@ -1,13 +1,12 @@
 ---
 name: "Brainstorm"
-why: "With many eyeballs on the code, all bugs are shallow. Colleagues can help you find bugs and improve the quality of your source code."
-how: "Code reviews can be done in many ways. The code can be presented on a big screen, so the entire team can do the review together. You can also ask one or two peers to simply sit behind your desk while you talk them through your code. Code analysis can also be a part of the workflow (e.g. every commit must be reviewed by someone else)."
-practice: "Code review sessions are often incorporated into software development projects. In Scrum, code reviews can be part of the ‘definition of done’. Pair programming can also be an effective way to let your work be continuously reviewed by a peer."
+why: "Generate and develop new ideas."
+how: "Bring people together to spark creativity and use a creativity technique to ensure a creative flow among the participants. Accept any ideas; filtering can be done in a later step. Build upon each other’s ideas, even bad ones. Avoid idea killers like early criticism."
+practice: "Companies use brainstorming techniques like nominal group technique or directed brainstorming."
 ingredients: [
-"Peers with a critical view.",
-"A willingness to improve weak points in your code.",
-"Code standards, a code style guide, checklists, etc.",
-"Use a tool or template like Business Model Canvas."
+"An activity plan.",
+"A shared problem statement and rules.",
+"An anything goes mindset: bad ideas also count as a contribution."
 ]
 category: "workshop"
 phases: [


### PR DESCRIPTION
# Description

Closes #176 

Fixes `Joker`, `Document analysis`, `Brainstorm`, `A/B Testing` from showing the incorrect content.
Copied content from https://oud.ictresearchmethods.nl into the correct markdown files

## Type of change

Please select the option that is relevant

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] All the required documentation is added.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
