### PR TITLE
Table colouring and wrapping tags

### DIFF
--- a/src/lib/components/PatternCard.svelte
+++ b/src/lib/components/PatternCard.svelte
@@ -145,6 +145,7 @@
 
 	.tag-container {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 0.5rem;
 		margin-top: 0.5rem;
 	}

--- a/src/lib/components/method/MethodTable.svelte
+++ b/src/lib/components/method/MethodTable.svelte
@@ -86,7 +86,11 @@
 
 	.item {
 		padding: 5px;
-		border: 1px solid white;
+		border: 1px solid var(--color-white);
+
+    &:first-child {
+        border-top: 2px solid var(--color-white);
+    }
 	}
 
 	a {


### PR DESCRIPTION
# Description

Closes none

Fixes the table colouring again and wraps tags when overflowing the page width.

## Type of change

Please select the option that is relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] All the required documentation is added.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

# Additional information